### PR TITLE
support for another feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ const { something, anotherThing } = require("things"); // => import { something,
 const something = require("things")(); // => import something from "things";
 require("things"); // => import "things";
 require("../things"); // => import "../things";
+const something = require("things").something(); // => import { something } from "things";
 ```
 
 ## Installation

--- a/lib/rona.js
+++ b/lib/rona.js
@@ -1,9 +1,10 @@
 const fs = require("fs");
 const re_normal = /^(const|let|var)\s+(\w+)\s+=(\s*require\((.\w+.))\)(;|)$/gim; // const name = require("name");
-const re_unique = /^(const|let|var)\s+(\w+)\s+=\s+require\((.+?)\).(\w+)(;|)$/gm; // const Bob = require("name").first
-const re_special = /^(const|let|var)\s+\{\s*(\w+.+)\s*}\s+=\s+require\((.+?)\)(;|)$/gm; // const { name } = require("name")
-const re_direct = /^require\((.+?)\)(;|)$/gm; // require("things")
+const re_unique = /^(const|let|var)\s+(\w+)\s+=\s+require\((.+?)\).(\w+)(;|)$/gim; // const Bob = require("name").first
+const re_special = /^(const|let|var)\s+\{\s*(\w+.+)\s*}\s+=\s+require\((.+?)\)(;|)$/gim; // const { name } = require("name")
+const re_direct = /^require\((.+?)\)(;|)$/gim; // require("things")
 const re_invoked = /^(const|let|var)\s*(\w+)\s*=(\s*require\((.\w+.))\)\(\)(;|)$/gim; // const name = require("person")()
+const re_unique_invoked = /^(const|let|var)\s+(\w+)\s+=\s+require\((.+?)\).(\w+)\(\)(;|)$/gim; // const something = require("things").something()
 // Go deeper no matter how project is structured and get all files with real path
 const files = [];
 basedir = process.argv[3];
@@ -55,7 +56,8 @@ const transform = file => {
       .replace(re_direct, `import $1`)
       .replace(re_unique, `import { $4 as $2 } from $3`)
       .replace(re_invoked, `import $2 from $4`)
-      .replace(re_special, `import { $2 } from $3`) + "\n"
+      .replace(re_unique_invoked, `import { $4 } from $3`)
+      .replace(re_special, `import { $2 } from $3`)
   );
 };
 module.exports = {


### PR DESCRIPTION
#### What does this PR do?
add support for transforming something like `const dotenv = require("dotenv").config()`
#### Description of Task to be completed?
`const something = require("things").something(); // => import { something } from "things";`
#### How should this be manually tested?
NA
#### Any background context you want to provide?
NA
#### Screenshots (if appropriate)
NA